### PR TITLE
case insensitive and make root key for registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,18 @@ var sleepMs = configWrapper.Get<int>("sleep-time-in-ms", 1000);
 
 #### WindowsRegistryConfigWrapper
 
-Loads from the Windows registry.
+Loads from the Windows registry, defining a root key for my application.
 
 ``` 
-IWritableConfigWrapper = new WindowsRegistryConfigWrapper();
-configWrapper.Set<int>("HKLM/MyApplication/MyKey", 5000); 
+IWritableConfigWrapper = new WindowsRegistryConfigWrapper("HKLM/MyApplication/");
+configWrapper.Set<int>("MyKey", 5000); 
 var sleepMs = configWrapper.Get<int>("sleep-time-in-ms", 5000);
 // sleepMs = 5000
 ```
 
 ##### WARNING
 
-While the WindowsRegistryConfigWrapper will not modify root level keys e.g. "HKLM", it should be used with care.  It is a sharp knife, be careful.
+While the WindowsRegistryConfigWrapper will not modify root level keys e.g. "`", it should be used with care.  It is a sharp knife, be careful.
 
 #### IniConfigWrapper
 
@@ -139,4 +139,4 @@ This project is licensed under the MIT License
 
 ## Acknowledgments
 
-* Hat tip to the teams at Spotlite (RallyHealth) and Guaranteed Rate for their feedback.
+* Hat tip to the teams at Spotlite (RallyHealth), Guaranteed Rate, GrubHub, and Endava for their feedback.

--- a/src/ConfigWrapper.Json/ConfigWrapper.json.nuspec
+++ b/src/ConfigWrapper.Json/ConfigWrapper.json.nuspec
@@ -5,7 +5,7 @@
     <id>ConfigWrapper.Json</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Brian Begy</authors>
@@ -18,7 +18,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
     <!-- Any details about this particular release -->
-    <releaseNotes>Support required config values by throwing an exception when not found.</releaseNotes>
+    <releaseNotes>Make keys case-insensitive.</releaseNotes>
     <title>ConfigWrapper.Json</title>
     <description>Helper classes to make it easier to work with json config files. Part of the ConfigWrapper project.</description>
     <copyright>Copyright ©2018 Brian Begy</copyright>

--- a/src/ConfigWrapper.Json/JsonConfigWrapper.cs
+++ b/src/ConfigWrapper.Json/JsonConfigWrapper.cs
@@ -43,9 +43,10 @@ namespace ConfigWrapper.Json
         /// <inheritdocs />
         protected override string GetValue(string key)
         {
-            if (this.AllKeys().Contains(key))
+            if (this.AllKeys().Any(aa=>aa.Equals(key, StringComparison.CurrentCultureIgnoreCase)))
             {
-                var obj = json.SelectToken(key);
+                var newKey = this.AllKeys().First(aa => aa.Equals(key, StringComparison.CurrentCultureIgnoreCase)); //get case-sensitive name since JSON cares
+                var obj = json.SelectToken(newKey);
                 return obj.ToString();
             }
             throw new Exception(String.Format("No config value found for key {0}.", key));

--- a/src/ConfigWrapper.Json/Properties/AssemblyInfo.cs
+++ b/src/ConfigWrapper.Json/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.1.0")]
-[assembly: AssemblyFileVersion("1.2.1.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/src/ConfigWrapper.Tests/ConfigWrapper.Tests.csproj
+++ b/src/ConfigWrapper.Tests/ConfigWrapper.Tests.csproj
@@ -48,7 +48,6 @@
     <Compile Include="IniTests.cs" />
     <Compile Include="InMemoryConfigWrapperTests.cs" />
     <Compile Include="JsonTests.cs" />
-    <Compile Include="WindowsRegistryConfigWrapperRootKeyTests.cs" />
     <Compile Include="WindowsRegistryConfigWrapperTests.cs" />
     <Compile Include="AppSettingsConfigWrapperTests.cs" />
     <Compile Include="HelpersTests.cs" />

--- a/src/ConfigWrapper.Tests/ConfigWrapper.Tests.csproj
+++ b/src/ConfigWrapper.Tests/ConfigWrapper.Tests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="IniTests.cs" />
     <Compile Include="InMemoryConfigWrapperTests.cs" />
     <Compile Include="JsonTests.cs" />
+    <Compile Include="WindowsRegistryConfigWrapperRootKeyTests.cs" />
     <Compile Include="WindowsRegistryConfigWrapperTests.cs" />
     <Compile Include="AppSettingsConfigWrapperTests.cs" />
     <Compile Include="HelpersTests.cs" />

--- a/src/ConfigWrapper.Tests/JsonTests.cs
+++ b/src/ConfigWrapper.Tests/JsonTests.cs
@@ -11,7 +11,6 @@ namespace ConfigWrapper.Tests
 
         [Test]
         [TestCase("simplekey", "value", "foo")]
-        [TestCase("simpleKey", "value", "value")]
         [TestCase("missingKey", "value", "value")]
         [TestCase("category.key", "value", "foo")]
         [TestCase("topcategory.subcategory.key", "value", "foo")]

--- a/src/ConfigWrapper.Tests/WindowsRegistryConfigWrapperTests.cs
+++ b/src/ConfigWrapper.Tests/WindowsRegistryConfigWrapperTests.cs
@@ -100,7 +100,7 @@ namespace ConfigWrapper.Tests
         [Test]
         public void MissingKeyTest()
         {
-            var ex = Assert.Throws<System.Exception>(() => sut.Get<double>(@"HKEY_CURRENT_USER\ConfigWrapper\nosuchKey"));
+            var ex = Assert.Throws<System.Exception>(() => sut.Get<double>(@"nosuchKey"));
             Assert.That(ex.Message, Does.StartWith($"No config value found"));
         }
     }

--- a/src/ConfigWrapper.Tests/WindowsRegistryConfigWrapperTests.cs
+++ b/src/ConfigWrapper.Tests/WindowsRegistryConfigWrapperTests.cs
@@ -8,7 +8,7 @@ namespace ConfigWrapper.Tests
     [TestFixture]
     public class WindowsRegistryConfigWrapperTests
     {
-        IWritableConfigWrapper sut = new WindowsRegistryConfigWrapper("HKCU/ConfigWrapper/Test/");
+        WindowsRegistryConfigWrapper sut = new WindowsRegistryConfigWrapper("HKCU/ConfigWrapper/Test/");
 
         [OneTimeSetUp]
         public void Setup() {
@@ -36,7 +36,7 @@ namespace ConfigWrapper.Tests
                 DeleteKey("integerfound");
                 DeleteKey("stringfound");
                 DeleteKey("doublefound");
-                DeleteKey("Test");
+                sut.Delete(sut.RootKey,true);
             }
             catch (System.Exception)
             {

--- a/src/ConfigWrapper.Tests/WindowsRegistryConfigWrapperTests.cs
+++ b/src/ConfigWrapper.Tests/WindowsRegistryConfigWrapperTests.cs
@@ -8,14 +8,14 @@ namespace ConfigWrapper.Tests
     [TestFixture]
     public class WindowsRegistryConfigWrapperTests
     {
-        IWritableConfigWrapper sut = new WindowsRegistryConfigWrapper();
+        IWritableConfigWrapper sut = new WindowsRegistryConfigWrapper("HKCU/ConfigWrapper/Test/");
 
         [OneTimeSetUp]
         public void Setup() {
-            sut.Set<int>("HKCU/ConfigWrapper/Test/integerfound", 1234, true);
-            sut.Set<string>("HKCU/ConfigWrapper/Test/stringfound", "stringfound", true);
-            sut.Set<double>("HKCU/ConfigWrapper/Test/doublefound", 12345.67D, true);
-            sut.Set<string>("HKCU/ConfigWrapper/Test/stringArrayFound", "spam|spam|spam|spam|spam|baked beans|spam");
+            sut.Set<int>("integerfound", 1234, true);
+            sut.Set<string>("stringfound", "stringfound", true);
+            sut.Set<double>("doublefound", 12345.67D, true);
+            sut.Set<string>("stringArrayFound", "spam|spam|spam|spam|spam|baked beans|spam");
         }
 
         private void DeleteKey(string key) {
@@ -33,11 +33,10 @@ namespace ConfigWrapper.Tests
         public void Teadown() {
             try
             {
-                DeleteKey("HKCU/ConfigWrapper/Test/integerfound");
-                DeleteKey("HKCU/ConfigWrapper/Test/stringfound");
-                DeleteKey("HKCU/ConfigWrapper/Test/doublefound");
-                DeleteKey("HKCU/ConfigWrapper/Test");
-                DeleteKey("HKCU/ConfigWrapper");
+                DeleteKey("integerfound");
+                DeleteKey("stringfound");
+                DeleteKey("doublefound");
+                DeleteKey("Test");
             }
             catch (System.Exception)
             {
@@ -47,8 +46,8 @@ namespace ConfigWrapper.Tests
         }
 
         [Test]
-        [TestCase("HKCU/ConfigWrapper/Test/invalidkey", 999, 999)]
-        [TestCase("HKCU/ConfigWrapper/Test/integerfound", 100, 1234)]
+        [TestCase("invalidkey", 999, 999)]
+        [TestCase("integerfound", 100, 1234)]
         public void IntegerTests(string key, int defaultValue, int expectedValue)
         {
             var result = sut.Get<int>(key, defaultValue);
@@ -56,8 +55,8 @@ namespace ConfigWrapper.Tests
         }
 
         [Test]
-        [TestCase("HKCU/ConfigWrapper/Test/invalidkey", "foo", "foo")]
-        [TestCase("HKCU/ConfigWrapper/Test/stringFound", "foo", "stringfound")]
+        [TestCase("invalidkey", "foo", "foo")]
+        [TestCase("stringFound", "foo", "stringfound")]
         public void StringTests(string key, string defaultValue, string expectedValue)
         {
             var result = sut.Get<string>(key, defaultValue);
@@ -65,8 +64,8 @@ namespace ConfigWrapper.Tests
         }
 
         [Test]
-        [TestCase("HKCU/ConfigWrapper/Test/invalidkey", 1.99D, 1.99D)]
-        [TestCase("HKCU/ConfigWrapper/Test/doublefound", 1.99D, 12345.67D)]
+        [TestCase("invalidkey", 1.99D, 1.99D)]
+        [TestCase("doublefound", 1.99D, 12345.67D)]
         public void DoubleTests(string key, double defaultValue, double expectedValue)
         {
             var result = sut.Get<double>(key, defaultValue);
@@ -74,8 +73,8 @@ namespace ConfigWrapper.Tests
         }
 
         [Test]
-        [TestCase("HKCU/ConfigWrapper/Test/invalid-key", new[] { "pork", "beans" }, new[] { "pork", "beans" })]
-        [TestCase("HKCU/ConfigWrapper/Test/stringArrayFound", new[] { "pork", "beans" }, new[] { "spam", "spam", "spam", "spam", "spam", "baked beans", "spam" })]
+        [TestCase("invalid-key", new[] { "pork", "beans" }, new[] { "pork", "beans" })]
+        [TestCase("stringArrayFound", new[] { "pork", "beans" }, new[] { "spam", "spam", "spam", "spam", "spam", "baked beans", "spam" })]
         public void StringArrayTests(string key, string[] defaultValue, string[] expectedValue)
         {
             var result = sut.Get<string>(key, defaultValue, new[] { ',','|' });
@@ -83,7 +82,7 @@ namespace ConfigWrapper.Tests
         }
 
         [Test]
-        [TestCase("HKCU/ConfigWrapper/Test/stringfound", 11, 1.09D)]
+        [TestCase("stringfound", 11, 1.09D)]
         public void DoubleBadCastTest(string key, double defaultValue, double expectedValue)
         {
             var ex = Assert.Throws<System.Exception>(() => sut.Get<double>(key, defaultValue, true));
@@ -93,9 +92,9 @@ namespace ConfigWrapper.Tests
         [Test]
         public void GetKeys()
         {
-            var result = sut.AllKeys("HKCU/ConfigWrapper");
+            var result = sut.AllKeys();
             result.Count().Should().Be(4);
-            result.First().Should().Be(@"HKEY_CURRENT_USER\ConfigWrapper\Test\integerfound");
+            result.Contains(@"HKEY_CURRENT_USER\ConfigWrapper\Test\integerfound");
         }
 
         [Test]

--- a/src/ConfigWrapper/ConfigWrapper.nuspec
+++ b/src/ConfigWrapper/ConfigWrapper.nuspec
@@ -5,7 +5,7 @@
     <id>ConfigWrapper</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.6.0</version>
+    <version>1.7.0</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Brian Begy</authors>

--- a/src/ConfigWrapper/ConfigWrapper.nuspec
+++ b/src/ConfigWrapper/ConfigWrapper.nuspec
@@ -18,7 +18,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
     <!-- Any details about this particular release -->
-    <releaseNotes>Support required config values by throwing an exception when not found.</releaseNotes>
+    <releaseNotes>Support concept of a root key in the WindowsRegistryConfigWrapper.</releaseNotes>
     <title>ConfigWrapper</title>
     <description>Helper classes to make it easier to work with config files in .net.  
       Supports using web.config, app.config, and Windows registry for configuration.  

--- a/src/ConfigWrapper/Properties/AssemblyInfo.cs
+++ b/src/ConfigWrapper/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.7.0.0")]
+[assembly: AssemblyFileVersion("1.7.0.0")]

--- a/src/ConfigWrapper/SimpleConfigWrapper.cs
+++ b/src/ConfigWrapper/SimpleConfigWrapper.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -31,7 +32,7 @@ namespace ConfigWrapper
         /// <param name="separators">how to separate the array</param>
         public T[] Get<T>(string key, char[] separators)
         {
-            if (!this.AllKeys().Contains(key))
+            if (!this.AllKeys().Any(aa => aa.Equals(key, StringComparison.CurrentCultureIgnoreCase)))
             {
                 throw new Exception(String.Format("No config value found for key {0}.", key));
             }
@@ -46,7 +47,7 @@ namespace ConfigWrapper
         /// <param name="key">key in the config</param>
         public T Get<T>(string key)
         {
-            if (!this.AllKeys().Contains(key))
+            if (!this.AllKeys().Any(aa => aa.Equals(key, StringComparison.CurrentCultureIgnoreCase)))
             {
                 throw new Exception(String.Format("No config value found for key {0}.", key));
             }
@@ -63,7 +64,7 @@ namespace ConfigWrapper
         /// <inheritdoc/>
         public virtual T Get<T>(string key, T defaultValue, bool errorOnWrongType)
         {
-            if (this.AllKeys().Contains(key))
+            if (this.AllKeys().Any(aa=>aa.Equals(key, StringComparison.CurrentCultureIgnoreCase)))
             {
                 return this.GetValue(key).CastAsT<T>(defaultValue, errorOnWrongType);
             }

--- a/src/ConfigWrapper/SimpleConfigWrapper.cs
+++ b/src/ConfigWrapper/SimpleConfigWrapper.cs
@@ -30,7 +30,7 @@ namespace ConfigWrapper
         /// <typeparam name="T">type of the value</typeparam>
         /// <param name="key">key in the config</param>
         /// <param name="separators">how to separate the array</param>
-        public T[] Get<T>(string key, char[] separators)
+        public virtual T[] Get<T>(string key, char[] separators)
         {
             if (!this.AllKeys().Any(aa => aa.Equals(key, StringComparison.CurrentCultureIgnoreCase)))
             {
@@ -45,7 +45,7 @@ namespace ConfigWrapper
         /// </summary>
         /// <typeparam name="T">type of the value</typeparam>
         /// <param name="key">key in the config</param>
-        public T Get<T>(string key)
+        public virtual T Get<T>(string key)
         {
             if (!this.AllKeys().Any(aa => aa.Equals(key, StringComparison.CurrentCultureIgnoreCase)))
             {


### PR DESCRIPTION
Creates the concept of a root key for windows registry configs.  This simplifies its use. 
Allow case-insensitive keys.