### PR TITLE
additional tests for keys with periods, allow fully-qualified key loo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Loads from the Windows registry, defining a root key for my application.
 ``` 
 IWritableConfigWrapper = new WindowsRegistryConfigWrapper("HKLM/Software/MyApplication/");
 configWrapper.Set<int>("MyKey", 5000); 
-var sleepMs = configWrapper.Get<int>("sleep-time-in-ms", 5000);
+var sleepMs = configWrapper.Get<int>("MyKey", 5000);
 // sleepMs = 5000
 ```
 
@@ -108,7 +108,7 @@ You can also give it fully-qualified key names as well, but it will use the cano
 ``` 
 IWritableConfigWrapper = new WindowsRegistryConfigWrapper("HKLM/Software/MyApplication/");
 configWrapper.Set<int>("HKEY_LOCAL_MACHINE/Software/MyApplication/MyKey", 5000); 
-var sleepMs = configWrapper.Get<int>("sleep-time-in-ms", 5000);
+var sleepMs = configWrapper.Get<int>("HKEY_LOCAL_MACHINE/Software/MyApplication/MyKey", 5000);
 // sleepMs = 5000
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,11 +97,21 @@ var sleepMs = configWrapper.Get<int>("sleep-time-in-ms", 1000);
 Loads from the Windows registry, defining a root key for my application.
 
 ``` 
-IWritableConfigWrapper = new WindowsRegistryConfigWrapper("HKLM/MyApplication/");
+IWritableConfigWrapper = new WindowsRegistryConfigWrapper("HKLM/Software/MyApplication/");
 configWrapper.Set<int>("MyKey", 5000); 
 var sleepMs = configWrapper.Get<int>("sleep-time-in-ms", 5000);
 // sleepMs = 5000
 ```
+
+You can also give it fully-qualified key names as well, but it will use the canonnical name of the root key: e.g. HKCU becomes HKEY_CURRENT_USER.
+
+``` 
+IWritableConfigWrapper = new WindowsRegistryConfigWrapper("HKLM/Software/MyApplication/");
+configWrapper.Set<int>("HKEY_LOCAL_MACHINE/Software/MyApplication/MyKey", 5000); 
+var sleepMs = configWrapper.Get<int>("sleep-time-in-ms", 5000);
+// sleepMs = 5000
+```
+
 
 ##### WARNING
 

--- a/src/ConfigWrapper.Tests/WindowsRegistryConfigWrapperTests.cs
+++ b/src/ConfigWrapper.Tests/WindowsRegistryConfigWrapperTests.cs
@@ -15,6 +15,7 @@ namespace ConfigWrapper.Tests
             sut.Set<int>("integerfound", 1234, true);
             sut.Set<string>("stringfound", "stringfound", true);
             sut.Set<double>("doublefound", 12345.67D, true);
+            sut.Set<string>("this.key.has.periods", "foo", true);
             sut.Set<string>("stringArrayFound", "spam|spam|spam|spam|spam|baked beans|spam");
         }
 
@@ -57,6 +58,9 @@ namespace ConfigWrapper.Tests
         [Test]
         [TestCase("invalidkey", "foo", "foo")]
         [TestCase("stringFound", "foo", "stringfound")]
+        [TestCase("StRiNgFoUnD", "foo", "stringfound")]
+        [TestCase("this.key.has.periods", "foo", "foo")]
+        [TestCase("HKCU/ConfigWrapper/Test/this.key.has.periods", "foo", "foo")]
         public void StringTests(string key, string defaultValue, string expectedValue)
         {
             var result = sut.Get<string>(key, defaultValue);
@@ -93,7 +97,7 @@ namespace ConfigWrapper.Tests
         public void GetKeys()
         {
             var result = sut.AllKeys();
-            result.Count().Should().Be(4);
+            result.Count().Should().Be(5);
             result.Contains(@"HKEY_CURRENT_USER\ConfigWrapper\Test\integerfound");
         }
 

--- a/src/ConfigWrapper/ConfigWrapper.nuspec
+++ b/src/ConfigWrapper/ConfigWrapper.nuspec
@@ -5,7 +5,7 @@
     <id>ConfigWrapper</id>
 
     <!-- The package version number that is used when resolving dependencies -->
-    <version>1.7.0</version>
+    <version>1.7.1</version>
 
     <!-- Authors contain text that appears directly on the gallery -->
     <authors>Brian Begy</authors>
@@ -18,7 +18,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
 
     <!-- Any details about this particular release -->
-    <releaseNotes>Support concept of a root key in the WindowsRegistryConfigWrapper.</releaseNotes>
+    <releaseNotes>Allow WindowsRegistryConfigWrapper to accept fully qualified or non-fully qualified keys.</releaseNotes>
     <title>ConfigWrapper</title>
     <description>Helper classes to make it easier to work with config files in .net.  
       Supports using web.config, app.config, and Windows registry for configuration.  

--- a/src/ConfigWrapper/Properties/AssemblyInfo.cs
+++ b/src/ConfigWrapper/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("1.7.1.0")]
+[assembly: AssemblyFileVersion("1.7.1.0")]

--- a/src/ConfigWrapper/WindowsRegistryConfigWrapper.cs
+++ b/src/ConfigWrapper/WindowsRegistryConfigWrapper.cs
@@ -365,6 +365,11 @@ namespace ConfigWrapper
 
         private string FullKey(string key)
         {
+            if (key.StartsWith(RootKey))
+            {
+                return key.Replace(@"\\", @"\");
+            }
+
             var combined = $"{RootKey}\\{key}".Replace("/", "\\");
             while (combined.Contains(@"\\"))
             {


### PR DESCRIPTION
Allow users to give the WindowsRegistryConfigWrapper either a short key e.g. "myKey" or the whole fully qualified key: "HKEY_CURRENT_USER\SOFTWARE\MYAPPLICATION\MYKEY"